### PR TITLE
improve default conf and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+

--- a/README.md
+++ b/README.md
@@ -74,11 +74,13 @@ A full example:
 **Example of running a server and an aql client that connects to it**
 
 1. Start the server with a namespace `segments` either by:
+
 i) Using environment variables:
 ```
 docker run -e "NAMESPACE=segments" -ti --name aerospike -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3003:3003 aerospike/aerospike-server
 ```
 OR
+
 ii) Use `aerospike.example.conf` as a configuration file:
 ```
 docker run -ti -v <absolute_path_to_local_repo>:/opt/aerospike/etc --name aerospike -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3003:3003 aerospike/aerospike-server /usr/bin/asd --foreground --config-file /opt/aerospike/etc/aerospike.example.conf

--- a/README.md
+++ b/README.md
@@ -69,6 +69,52 @@ A full example:
 
 	docker run -tid -v <DIRECTORY>:/opt/aerospike/etc --name aerospike -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3003:3003 aerospike/aerospike-server /usr/bin/asd --foreground --config-file /opt/aerospike/etc/aerospike.conf
 
+**NOTE**: The template file `aerospike.template.conf` cannot be used without substituting actual values for `${SERVICE_THREADS}`, `${TRANSACTION_QUEUES}` etc. Use `aerospike.example.conf` for a configuration file that can be used as is. This file initializes a namespace (analogous to `database` in SQL) `segments`
+
+**Example of running a server and an aql client that connects to it**
+
+1. Start the server with a namespace `segments` either by:
+i) Using environment variables:
+```
+docker run -e "NAMESPACE=segments" -ti --name aerospike -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3003:3003 aerospike/aerospike-server
+```
+OR
+ii) Use `aerospike.example.conf` as a configuration file:
+```
+docker run -ti -v <absolute_path_to_local_repo>:/opt/aerospike/etc --name aerospike -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3003:3003 aerospike/aerospike-server /usr/bin/asd --foreground --config-file /opt/aerospike/etc/aerospike.example.conf
+```
+
+**Running a client cli that talks to this server**:
+1. Start `aql` (stands for aerospike query language, this is analogous to `psql` or `redis-cli`):
+```
+docker run -ti --name aerospike-tools --link /aerospike:aerospike aerospike/aerospike-tools aql
+```
+
+2. Show all the available namespaces:
+```
+aql> show namespaces
++------------+
+| namespaces |
++------------+
+| "segments" |
++------------+
+[172.17.0.2:3000] 1 row in set (0.002 secs)
+```
+
+3. Insert something into a set `FS1` (analogous to a table) in the namespace `segments`:
+```
+aql> insert into segments.FS1 (PK, chunkbytes) values ('anirudh.ts', 34)
+OK, 1 record affected.
+
+aql> select * from segments
++------------+
+| chunkbytes |
++------------+
+| 34         |
++------------+
+1 row in set (0.166 secs)
+```
+
 ## access-address Configuration
 
 In order for Aerospike to properly broadcast its address to the cluster or applications, the **access-address** needs to be set in the configuration file. If it is not set, then the IP address within the container will be used, which is not accessible to other nodes.

--- a/aerospike.example.conf
+++ b/aerospike.example.conf
@@ -63,7 +63,7 @@ network {
 	}
 }
 
-namespace shmegments {
+namespace segments {
 	replication-factor 2
 	memory-size 1G
 	default-ttl 3d # 3 days, use 0 to never expire/evict.

--- a/aerospike.example.conf
+++ b/aerospike.example.conf
@@ -1,0 +1,84 @@
+# Aerospike database configuration file.
+# Modified from aerospike.template.conf to be able to use this config-file as is
+
+# This stanza must come first.
+service {
+	user root
+	group root
+	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
+	pidfile /var/run/aerospike/asd.pid
+	# in order to use non-default options, replace ${SERVICE_THREADS}, etc. with a number
+	# service-threads ${SERVICE_THREADS}
+	# transaction-queues ${TRANSACTION_QUEUES}
+	# transaction-threads-per-queue ${TRANSACTION_THREADS_PER_QUEUE}
+	proto-fd-max 15000
+}
+
+logging {
+
+	# Log file must be an absolute path.
+	file /var/log/aerospike/aerospike.log {
+		context any info
+	}
+
+	# Send log messages to stdout
+	console {
+		context any info 
+	}
+}
+
+network {
+	service {
+		address any
+		port 3000
+
+		# Uncomment the following to set the `access-address` parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+
+        # address ${HB_ADDRESS}
+		# mesh is used for environments that do not support multicast
+		# multicast is the preferred approach but is currently not supported on docker
+		mode mesh
+		port 3002
+
+		# use asinfo -v 'tip:host=<ADDR>;port=3002' to inform cluster of
+		# other mesh nodes
+
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		port 3001
+	}
+
+	info {
+		port 3003
+	}
+}
+
+namespace shmegments {
+	replication-factor 2
+	memory-size 1G
+	default-ttl 3d # 3 days, use 0 to never expire/evict.
+
+	#   storage-engine memory
+
+	# To use in memory only storage, uncomment the above line and comment out the
+	# following storage-engine section
+
+	storage-engine device {
+		file /opt/aerospike/data/segments.dat
+		filesize 10G
+		data-in-memory true # Store data in memory in addition to file.
+	}
+
+	# add more namespaces here if necessary
+}
+

--- a/aerospike.example.conf
+++ b/aerospike.example.conf
@@ -7,7 +7,8 @@ service {
 	group root
 	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
 	pidfile /var/run/aerospike/asd.pid
-	# in order to use non-default options, replace ${SERVICE_THREADS}, etc. with a number
+	# commenting out the following lines uses default values for service-threads, transaction-queues, etc.
+	# in order to use non-default values, replace ${SERVICE_THREADS}, etc. with a number
 	# service-threads ${SERVICE_THREADS}
 	# transaction-queues ${TRANSACTION_QUEUES}
 	# transaction-threads-per-queue ${TRANSACTION_THREADS_PER_QUEUE}


### PR DESCRIPTION
1. Add example for running server in docker and connecting aql to it
2. Improve template conf (either comment out variables like `${SERVICE_ADDRESS}` or replace them with default values when they are necessary, e.g. port). Annoyingly, this is necessary to be able to parse the conf at startup without error.